### PR TITLE
[Java API] Improve Java Addition Model Test

### DIFF
--- a/source/neuropod/bindings/java/BUILD
+++ b/source/neuropod/bindings/java/BUILD
@@ -149,16 +149,53 @@ java_test(
 )
 
 java_test(
-    name = "NeuropodTest",
-    srcs = ["src/test/java/com/uber/neuropod/NeuropodTest.java"],
+    name = "TFAdditionTest",
+    srcs = [
+        "src/test/java/com/uber/neuropod/NeuropodAdditionTest.java",
+        "src/test/java/com/uber/neuropod/TFAdditionTest.java",
+    ],
     data = [
         "//neuropod/backends/tensorflow:libneuropod_tensorflow_backend.so",
+        "//neuropod/tests/test_data",
+    ],
+    javacopts = JAVACOPTS,
+    tags = ["requires_path"],
+    test_class = "com.uber.neuropod.TFAdditionTest",
+    deps = [
+        ":neuropod_java_jar",
+        "@junit",
+    ],
+)
+
+java_test(
+    name = "TorchscriptAdditionTest",
+    srcs = [
+        "src/test/java/com/uber/neuropod/NeuropodAdditionTest.java",
+        "src/test/java/com/uber/neuropod/TorchscriptAdditionTest.java",
+    ],
+    data = [
         "//neuropod/backends/torchscript:libneuropod_torchscript_backend.so",
         "//neuropod/tests/test_data",
     ],
     javacopts = JAVACOPTS,
     tags = ["requires_path"],
-    test_class = "com.uber.neuropod.NeuropodTest",
+    test_class = "com.uber.neuropod.TorchscriptAdditionTest",
+    deps = [
+        ":neuropod_java_jar",
+        "@junit",
+    ],
+)
+
+java_test(
+    name = "DifferentFeaturesTest",
+    srcs = ["src/test/java/com/uber/neuropod/DifferentFeaturesTest.java"],
+    data = [
+        "//neuropod/backends/torchscript:libneuropod_torchscript_backend.so",
+        "//neuropod/tests/test_data",
+    ],
+    javacopts = JAVACOPTS,
+    tags = ["requires_path"],
+    test_class = "com.uber.neuropod.DifferentFeaturesTest",
     deps = [
         ":neuropod_java_jar",
         "@junit",

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/DifferentFeaturesTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/DifferentFeaturesTest.java
@@ -1,0 +1,47 @@
+/* Copyright (c) 2020 UATC, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.uber.neuropod;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class DifferentFeaturesTest {
+    @Before
+    public void setUp() throws Exception {
+        LibraryLoader.load();
+        // Set the test mode to true to use override library path
+        LibraryLoader.setTestMode(true);
+    }
+
+    @Test
+    public void getOutputsTestSymbol() {
+        // Load model that we know has named dimensions.
+        final String modelPath = "neuropod/tests/test_data/torchscript_addition_model_single_output/";
+        RuntimeOptions opts = new RuntimeOptions();
+        opts.useOpe = true;
+        try (Neuropod torchModel = new Neuropod(modelPath, opts)) {
+            Set<TensorSpec> outputs = new HashSet<>(torchModel.getOutputs());
+            Set<TensorSpec> expected = new HashSet<>(Arrays.asList(
+                    new TensorSpec("out", TensorType.FLOAT_TENSOR,
+                            Arrays.asList(new Dimension("batch_size"), new Dimension(-1)))));
+            assertEquals(outputs, expected);
+        }
+    }
+}

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TFAdditionTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TFAdditionTest.java
@@ -1,0 +1,27 @@
+/* Copyright (c) 2020 UATC, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.uber.neuropod;
+
+import org.junit.Before;
+
+public class TFAdditionTest extends NeuropodAdditionTest {
+    @Before
+    public void setUp() throws Exception {
+        this.model_path = "neuropod/tests/test_data/tf_addition_model/";
+        this.platform = "tensorflow";
+        this.prepareEnvironment();
+    }
+}

--- a/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TorchscriptAdditionTest.java
+++ b/source/neuropod/bindings/java/src/test/java/com/uber/neuropod/TorchscriptAdditionTest.java
@@ -1,0 +1,27 @@
+/* Copyright (c) 2020 UATC, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.uber.neuropod;
+
+import org.junit.Before;
+
+public class TorchscriptAdditionTest extends NeuropodAdditionTest {
+    @Before
+    public void setUp() throws Exception {
+        this.model_path = "neuropod/tests/test_data/torchscript_addition_model/";
+        this.platform = "torchscript";
+        this.prepareEnvironment();
+    }
+}


### PR DESCRIPTION
### Summary:
NeuropodAdditionTest can be generic test that works with TF and Torchscript addition models. Now NeuropodAdditionTest implements tests, derived TF and Torchscript classes only prepare test environment and specify appropriate model config.

### Test Plan:
Build and then run Java tests:
python ../build/run_bazel_tests.py --lang java
